### PR TITLE
Implement PImMS parser

### DIFF
--- a/src/io/PImMSParser.m
+++ b/src/io/PImMSParser.m
@@ -1,15 +1,37 @@
 classdef PImMSParser < Parser
+    properties (Constant)
+        Name = 'PImMS Binary';
+    end
+
+    properties (SetAccess = protected)
+        % Time-of-flight properties
+        tof_start;
+        tof_end;
+        tof_range;
+
+        % Image data variable
+        image_data;
+    end
+
     methods (Static)
         function filterSpec = getFilterSpec()
-            % TODO: Fill in this method by returning
+            filterSpec = {'*.bin', 'PImMS Binary (*.bin)'};
         end
     end
 
     methods
-        function this = SkeletonParser(filename)
+        function this = PImMSParser(filename)
             this.filename = filename;
 
-            % TODO: Any other set up details here
+            % Check that the filename ends in .bin
+            [pathstr,name,ext] = fileparts(filename);
+
+            if(~strcmpi(ext, '.bin'))
+                exception = MException('PImMSParser:FailedToParse', ...
+                    ['Must supply a BIN (*.bin) file']);
+                throw(exception);
+            end
+
         end
 
 
@@ -17,27 +39,106 @@ classdef PImMSParser < Parser
             % Display a message to the user that parsing has started
             notify(this, 'ParsingStarted');
 
+            % Assume data is PImMS2 (324x324)
             % TODO: Perform any parsing of the data here. Making sure that width and height are filled in
-            this.width = ??;
-            this.height = ??;
+            this.width = 324;
+            this.height = 324;
+
+            % Set limits on how much of the time-of-flight to read
+            this.tof_start = 0;
+            this.tof_end = 4095;
+
+            % Check the tof start and end falls within the timestamp range of PImMS
+            if(this.tof_start < 0)
+                this.tof_start = 0;
+            end
+            if(this.tof_end > 4095)
+                this.tof_end = 4095;
+            end
+
+            this.tof_range = this.tof_end - this.tof_start + 1;
+
+            % Read the PImMS file into an array
+            % Initialise array
+            this.image_data = zeros(this.height,this.width,this.tof_range);
+
+            % Open the file
+            fileID = fopen(this.filename, 'r');
+
+            if(this.tof_range == 4096)
+                % Loop through each frame and read the data with no need to account for different array sizes
+                while 1
+                    try
+                        m = fread(fileID, 1, 'int32');
+                        n = fread(fileID, 1, 'int32');
+                        data = transpose(reshape(fread(fileID, m*n, 'uint16'),[n,m]) + 1);
+                    catch err
+                        break
+                    end
+
+                    % Add one to the image for each ion hit
+                    for i = 1:size(data,1)
+                        this.image_data(data(i,1),data(i,2),data(i,3)) = this.image_data(data(i,1),data(i,2),data(i,3)) + 1;
+                    end
+                end
+            else
+                % Loop through each frame and read the data
+                while 1
+                    try
+                        m = fread(fileID, 1, 'int32');
+                        n = fread(fileID, 1, 'int32');
+                        if(m==0)
+                          continue;
+                        end
+                        data = transpose(reshape(fread(fileID, m*n, 'uint16'),[n,m]) + 1);
+                    catch err
+                        break
+                    end
+                    % Make sure the indexing is correct and find valid
+                    % indexes
+                    data(:,3) = data(:,3) - this.tof_start;
+                    data = data(data(:,3) > 0 & data(:,3) < this.tof_range + 1,:);
+
+                    % Add one to the image for each ion hit
+                    for i = 1:size(data,1)
+                        this.image_data(data(i,1),data(i,2),data(i,3)) = this.image_data(data(i,1),data(i,2),data(i,3)) + 1;
+                    end
+                end
+
+            end
+
+            % Close the file
+            fclose(fileID);
 
             % Close the message and notify the user that parsing is complete
             notify(this, 'ParsingComplete');
         end
 
-        function [spectralChannels, intensities] = getSpectrum(this, x, y)
-            % TODO: Read in the data for the spectrum at location (x, y). If one doesn't exist then set spectralChannels and intensities to be empty
+        function spectrum = getSpectrum(this, x, y)
+            % Read in the data for the spectrum at location (x, y). If one doesn't exist then set spectralChannels and intensities to be empty
 
-            spectralChannels = ??;
-            intensities = ??;
+            spectralChannels = transpose(this.tof_start:this.tof_end);
+            intensities = reshape(this.image_data(x,y,:),[],1);
+
+            spectrum = SpectralData(spectralChannels, intensities);
+        end
+
+        function image = getImage(this, spectralChannel, channelWidth)
+            % Create an image for a defined timestamp range
+            image = Image(sum(this.image_data(:,:,spectralChannel:SpectralChannel + channelWidth - 1),3));
         end
 
         function image = getOverviewImage(this)
-            imageData = zeros(this.height, this.width);
+            % Create an overview image by summing over the time axis
+            image = Image(sum(this.image_data,3));
+        end
 
-            % TODO: Create an image that describes the dataset. This is displayed in the `Select Data Representation' interface when loading a dataset
+        function spectrum = getOverviewSpectrum(this)
+            % Create an overview tof by summing over the image for each timestamp
+            spectralChannels = transpose(this.tof_start:this.tof_end);
+            intensities = reshape(sum(this.image_data,[1,2]),[],1);
 
-            image = Image(imageData);
+            spectrum = SpectralData(spectralChannels, intensities);
         end
     end
 end

--- a/src/io/PImMSParser.m
+++ b/src/io/PImMSParser.m
@@ -1,0 +1,43 @@
+classdef PImMSParser < Parser
+    methods (Static)
+        function filterSpec = getFilterSpec()
+            % TODO: Fill in this method by returning
+        end
+    end
+
+    methods
+        function this = SkeletonParser(filename)
+            this.filename = filename;
+
+            % TODO: Any other set up details here
+        end
+
+
+        function parse(this)
+            % Display a message to the user that parsing has started
+            notify(this, 'ParsingStarted');
+
+            % TODO: Perform any parsing of the data here. Making sure that width and height are filled in
+            this.width = ??;
+            this.height = ??;
+
+            % Close the message and notify the user that parsing is complete
+            notify(this, 'ParsingComplete');
+        end
+
+        function [spectralChannels, intensities] = getSpectrum(this, x, y)
+            % TODO: Read in the data for the spectrum at location (x, y). If one doesn't exist then set spectralChannels and intensities to be empty
+
+            spectralChannels = ??;
+            intensities = ??;
+        end
+
+        function image = getOverviewImage(this)
+            imageData = zeros(this.height, this.width);
+
+            % TODO: Create an image that describes the dataset. This is displayed in the `Select Data Representation' interface when loading a dataset
+
+            image = Image(imageData);
+        end
+    end
+end


### PR DESCRIPTION
This code implements a parser for the Pixel Imaging Mass Spectrometry (PImMS) camera's binary data format. PImMS is an ultrafast imaging sensor typically used in time-of-flight mass spectrometry experiments. In an experimental cycle, the x, y and t coordinates of each event detected by the camera is recorded, where x is the x coordinate, y is the y coordinate and t is the timestamp.

This code has been implemented assuming the use of a PImMS2 camera, which has a 324x324 pixel sensor and 4096 timestamps. To reduce the memory usage when parsing, a subset of the timestamp range can be selected by adjusting the value of this.tof_start and this.tof_end on lines 48 and 49, respectively.

It would be beneficial if the spectrum of the entire image could also be displayed using SpectralAnalysis, perhaps displaying immediately after the data has been loaded in a similar way to the overview image. The underlying code to produce the spectrum has been included in the parser.